### PR TITLE
Microsoft Ads is now compatible with provider.

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -97,6 +97,7 @@ class Provider extends AbstractProvider
     {
         return array_merge(parent::getTokenFields($code), [
             'grant_type' => 'authorization_code',
+            'scope' => parent::formatScopes(parent::getScopes(), $this->scopeSeparator),
         ]);
     }
 


### PR DESCRIPTION
Added support for Microsoft Ads, which requires `scope` to be included in the `POST` request to the token url.

See the example:
https://docs.microsoft.com/en-us/advertising/guides/get-started?view=bingads-13#quick-start-production

```powershell
# Get the initial access and refresh tokens. 

$response = Invoke-WebRequest https://login.microsoftonline.com/common/oauth2/v2.0/token -ContentType application/x-www-form-urlencoded -Method POST -Body "client_id=$clientId&scope=https://ads.microsoft.com/ads.manage%20offline_access&code=$code&grant_type=authorization_code&redirect_uri=https%3A%2F%2Flogin.microsoftonline.com%2Fcommon%2Foauth2%2Fnativeclient"
```

