### PR TITLE
Update email field to return the email

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -179,7 +179,7 @@ class Provider extends AbstractProvider
             'id'       => $user['id'],
             'nickname' => null,
             'name'     => $user['displayName'],
-            'email'    => $user['userPrincipalName'],
+            'email'    => $user['mail'],
             'avatar'   => Arr::get($user, 'avatar'),
 
             'businessPhones'    => Arr::get($user, 'businessPhones'),


### PR DESCRIPTION
Base package `laravel/socialite` has the method `getEmail` within the [AbstractUser](https://github.com/laravel/socialite/blob/5.x/src/AbstractUser.php#L94) because this is returning the `userPrincipalName` that base method is returning an empty string.

This PR is to return the correct field. 

Side not the `userPrincipalName` is return on #195 of the provider